### PR TITLE
docs: 增强中文语音输入搜索召回首屏文案

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,11 @@
 <h1 align="center">Whisper Input / 轻语输入</h1>
 
 <p align="center">
-  An AI voice input tool for Windows professionals: turns spoken words into polished, structured text ready to send, report, or hand off.
+  Windows AI voice input: press a global hotkey, speak in Chinese, turn speech to text, polish spoken words, structure the result, and insert it at the current cursor position.
+</p>
+
+<p align="center">
+  中文搜索意图：<strong>Windows 语音输入</strong>、<strong>快捷键语音转文字</strong>、<strong>按住说话自动输入</strong>、<strong>插入光标</strong>、<strong>去口头语润色</strong>、<strong>结构化文本</strong>。
 </p>
 
 <p align="center">
@@ -20,13 +24,17 @@
   <a href="https://github.com/EthanYoQ/whisper-input/stargazers"><img src="https://badgen.net/github/stars/EthanYoQ/whisper-input" alt="GitHub stars" /></a>
 </p>
 
+<p align="center">
+  <a href="https://github.com/EthanYoQ/whisper-input/releases/latest">Download latest Windows installer</a>
+</p>
+
 ---
 
 ## 🎯 At a Glance
 
 Whisper Input is not a traditional IME, nor a meeting transcription tool.
 
-It does one thing: **press a shortcut key, speak, and it turns your spoken words into natural, well-structured text at your cursor position.**
+It does one thing: **press a shortcut key, speak, and it turns your spoken words into natural, well-structured text at your cursor position.** If direct insertion fails, the result is copied to the clipboard as a fallback.
 
 Here are some typical scenarios:
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -11,7 +11,11 @@
 <h1 align="center">轻语输入 / Whisper Input</h1>
 
 <p align="center">
-  面向 Windows 职场用户的 AI 语音输入工具：把口语变成可发送、可汇报、可交接的文字。
+  面向 Windows 职场用户的 AI 语音输入工具：按全局快捷键说话，把中文语音转文字，去口头语并润色成结构化文本，插入当前光标。
+</p>
+
+<p align="center">
+  搜索意图：<strong>Windows 语音输入</strong>、<strong>快捷键语音转文字</strong>、<strong>按住说话自动输入</strong>、<strong>插入光标</strong>、<strong>去口头语润色</strong>、<strong>结构化文本</strong>。
 </p>
 
 <p align="center">
@@ -20,13 +24,17 @@
   <a href="https://github.com/EthanYoQ/whisper-input/stargazers"><img src="https://badgen.net/github/stars/EthanYoQ/whisper-input" alt="GitHub stars" /></a>
 </p>
 
+<p align="center">
+  <a href="https://github.com/EthanYoQ/whisper-input/releases/latest">下载最新版 Windows 安装包</a>
+</p>
+
 ---
 
 ## 🎯 一句话说明
 
 轻语输入不是传统输入法，也不是会议记录软件。
 
-它只做一件事：**你按下快捷键说话，它把你的口语整理成自然、正式、结构清楚的文字，并插入到当前光标位置。**
+它只做一件事：**你按下快捷键说话，它把你的口语整理成自然、正式、结构清楚的文字，并插入到当前光标位置。** 如果直接插入失败，会自动复制到剪贴板兜底。
 
 适合这些场景：
 


### PR DESCRIPTION
## 摘要

- 改写 README / README_zh 首屏说明。
- 引入中文搜索意图：Windows 语音输入、快捷键语音转文字、按住说话自动输入、插入光标、去口头语润色、结构化文本。
- 增加 latest release 下载入口。
- 明确插入失败时复制到剪贴板兜底，避免过度承诺。

## 背景

WorkBuddy 的搜索实验显示，当前仓库只在少数英文 GitHub CLI 查询中出现，中文 GitHub 查询和 WebSearch 没有召回。线上 Description、Topics 和 latest Release 文案已经按实验 A 先行更新；这个 PR 补 README 首屏。

## 复测计划

- 复跑场景 B GitHub CLI 查询矩阵。
- 复跑场景 B WebSearch 查询。
- 观察 GitHub Traffic、Release downloads 和目标仓库 Recall@20。
