### PR TITLE
docs: 增强 OpenLess 与 Typeless 替代品搜索召回

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,14 +8,18 @@
   <img src="./public/AppIcon.png" width="104" height="104" alt="Whisper Input Logo" />
 </p>
 
-<h1 align="center">Whisper Input / 轻语输入</h1>
+<h1 align="center">Whisper Input / Qingyu — OpenLess-based Windows Voice Typing</h1>
 
 <p align="center">
-  Windows AI voice input: press a global hotkey, speak in Chinese, turn speech to text, polish spoken words, structure the result, and insert it at the current cursor position.
+  An OpenLess-based Windows AI voice input tool for Chinese workplace writing: hold a global hotkey, speak naturally, turn speech to text, remove filler words, polish or structure the result, and insert it at the current cursor position.
 </p>
 
 <p align="center">
-  中文搜索意图：<strong>Windows 语音输入</strong>、<strong>快捷键语音转文字</strong>、<strong>按住说话自动输入</strong>、<strong>插入光标</strong>、<strong>去口头语润色</strong>、<strong>结构化文本</strong>。
+  Search intent: <strong>OpenLess alternative</strong>, <strong>Typeless alternative</strong>, <strong>typeless-alternative</strong>, <strong>Windows voice typing</strong>, <strong>AI voice dictation</strong>, <strong>Chinese speech-to-text</strong>, <strong>workplace dictation</strong>, <strong>Chinese-to-English voice input</strong>.
+</p>
+
+<p align="center">
+  中文搜索意图：<strong>OpenLess 改造版</strong>、<strong>Typeless 平替</strong>、<strong>开源 Typeless</strong>、<strong>Windows 语音输入</strong>、<strong>快捷键语音转文字</strong>、<strong>职场语音输入</strong>、<strong>中文转英文语音输入</strong>。
 </p>
 
 <p align="center">
@@ -35,6 +39,8 @@
 Whisper Input is not a traditional IME, nor a meeting transcription tool.
 
 It does one thing: **press a shortcut key, speak, and it turns your spoken words into natural, well-structured text at your cursor position.** If direct insertion fails, the result is copied to the clipboard as a fallback.
+
+This project is built upon [OpenLess](https://github.com/Open-Less/openless), but it is not an official OpenLess distribution and is not affiliated with Typeless. It explores a Windows-first, cloud-first, BYOK direction for people searching for an open-source Typeless-style voice typing workflow in Chinese workplace scenarios.
 
 Here are some typical scenarios:
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -8,14 +8,14 @@
   <img src="./public/AppIcon.png" width="104" height="104" alt="Whisper Input Logo" />
 </p>
 
-<h1 align="center">轻语输入 / Whisper Input</h1>
+<h1 align="center">轻语输入 / Whisper Input — OpenLess 改造版，Typeless 平替方向</h1>
 
 <p align="center">
-  面向 Windows 职场用户的 AI 语音输入工具：按全局快捷键说话，把中文语音转文字，去口头语并润色成结构化文本，插入当前光标。
+  基于 OpenLess 改造，面向 Windows 职场用户的中文 AI 语音输入工具：按全局快捷键说话，把中文语音转文字，去口头语并润色成结构化文本，插入当前光标。
 </p>
 
 <p align="center">
-  搜索意图：<strong>Windows 语音输入</strong>、<strong>快捷键语音转文字</strong>、<strong>按住说话自动输入</strong>、<strong>插入光标</strong>、<strong>去口头语润色</strong>、<strong>结构化文本</strong>。
+  搜索意图：<strong>OpenLess 改造版</strong>、<strong>OpenLess 中文版</strong>、<strong>Typeless 平替</strong>、<strong>开源 Typeless</strong>、<strong>typeless-alternative</strong>、<strong>Windows 语音输入</strong>、<strong>职场语音输入</strong>、<strong>中文转英文语音输入</strong>。
 </p>
 
 <p align="center">
@@ -35,6 +35,8 @@
 轻语输入不是传统输入法，也不是会议记录软件。
 
 它只做一件事：**你按下快捷键说话，它把你的口语整理成自然、正式、结构清楚的文字，并插入到当前光标位置。** 如果直接插入失败，会自动复制到剪贴板兜底。
+
+它基于 [OpenLess](https://github.com/Open-Less/openless) 改造，但不是 OpenLess 官方发行版，也不是 Typeless 官方产品。这里的 Typeless / Typeless 平替 / 开源 Typeless 只用于说明用户常见的检索意图：用开源、可自带 API Key 的方式实现类似“按住说话、松开得到润色文字”的工作流，并更聚焦中文职场表达。
 
 适合这些场景：
 


### PR DESCRIPTION
## 变更内容

- 将 README 首屏定位改为 `OpenLess-based Windows Voice Typing`。
- 在中英文 README 首屏加入 OpenLess、Typeless alternative、Typeless 平替、开源 Typeless、Windows voice typing、AI voice dictation、职场语音输入、中文转英文语音输入等搜索意图。
- 将“基于 OpenLess 改造”前置，同时明确不是 OpenLess 官方发行版，也不隶属于 Typeless。

## 为什么这样改

实验 A 已经覆盖了中文语音输入基础词。本轮实验 B 扩展到竞品 / 替代品检索词，测试 `OpenLess`、`Typeless`、`typeless-alternative`、`职场语音输入`、`中文转英文语音输入` 这类搜索意图是否能带来更好的 GitHub 搜索召回。

没有写入 `80% Typeless 效果` 这类未验证效果比例，避免 README 出现无法证明的比较声明。

## 验证

- `git diff --check`

