### PR TITLE
feat: 让灵动岛胶囊跟随鼠标光标 (Capsule follows mouse cursor)

### DIFF
--- a/src-tauri/src/coordinator.rs
+++ b/src-tauri/src/coordinator.rs
@@ -4654,7 +4654,7 @@ fn emit_capsule(
         // Windows 上 linger 的真实问题（截图选中 / 死区 / 拖拽卡顿）由 #140 加的
         // `hide_capsule_window_if_present()` Win32 hard-hide 在 visible=false 分支
         // 处理，不依赖把 Done/Cancelled/Error 打成 invisible。详见 PR #140 评论。
-        maybe_position_capsule_bottom_center(&inner_for_main, &window, translation);
+        maybe_position_capsule_near_cursor(&inner_for_main, &window, translation);
         if show_capsule && visible {
             if !show_capsule_window_no_activate(&app_for_main, &window) {
                 let _ = window.show();
@@ -4755,32 +4755,12 @@ fn update_atomic_max(target: &AtomicU64, value: u64) {
     }
 }
 
-fn maybe_position_capsule_bottom_center<R: tauri::Runtime>(
-    inner: &Arc<Inner>,
+fn maybe_position_capsule_near_cursor<R: tauri::Runtime>(
+    _inner: &Arc<Inner>,
     window: &tauri::WebviewWindow<R>,
     translation_active: bool,
 ) {
-    let Some(monitor) = window.current_monitor().ok().flatten() else {
-        return;
-    };
-    let next = CapsuleLayoutState {
-        translation_active,
-        monitor_x: monitor.position().x,
-        monitor_y: monitor.position().y,
-        monitor_width: monitor.size().width,
-        monitor_height: monitor.size().height,
-        scale_bits: monitor.scale_factor().to_bits(),
-    };
-    {
-        let last = inner.capsule_layout.lock();
-        if last.as_ref() == Some(&next) {
-            return;
-        }
-    }
-    if crate::position_capsule_bottom_center(window, translation_active).is_ok() {
-        let mut last = inner.capsule_layout.lock();
-        *last = Some(next);
-    }
+    let _ = crate::position_capsule_near_cursor(window, translation_active);
 }
 
 // ─────────────────────────── audio bridge ───────────────────────────

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1139,6 +1139,31 @@ fn show_qa_window_no_activate<R: tauri::Runtime>(window: &tauri::WebviewWindow<R
     true
 }
 
+pub(crate) fn position_capsule_near_cursor<R: tauri::Runtime>(
+    window: &tauri::WebviewWindow<R>,
+    translation_active: bool,
+) -> tauri::Result<()> {
+    let bounds = capsule_window_bounds(translation_active);
+    window.set_size(LogicalSize::new(bounds.width, bounds.height))?;
+
+    if let Ok(cursor_pos) = window.cursor_position() {
+        if let Some(monitor) = window.current_monitor()? {
+            let scale = monitor.scale_factor();
+            let logical_x = cursor_pos.x as f64 / scale;
+            let logical_y = cursor_pos.y as f64 / scale;
+
+            // Offset the capsule near the cursor (15px right, 25px below)
+            let x = logical_x + 15.0;
+            let y = logical_y + 25.0;
+
+            window.set_position(LogicalPosition::new(x, y))?;
+            return Ok(());
+        }
+    }
+
+    position_capsule_bottom_center(window, translation_active)
+}
+
 /// 把 capsule 窗口移到屏幕底部居中，与 Swift `CapsuleWindowController.repositionToBottomCenter` 同效。
 /// 留 80pt 给 macOS Dock；Windows 任务栏一般在底部 48pt 以内，整体也合适。
 pub(crate) fn position_capsule_bottom_center<R: tauri::Runtime>(


### PR DESCRIPTION
﻿### 💡 改进内容
目前的录音胶囊（Capsule / 灵动岛）是固定显示在屏幕底部居中。由于人在打字时视线聚焦在输入光标附近，底部居中的提示有时不够显眼。

这个 PR 增加了一个微创新体验：**让胶囊动态跟随光标**。
修改了 position_capsule_bottom_center 逻辑，在呼出胶囊时优先获取系统光标的当前位置，并让胶囊在光标的右下方（偏移量 X+15, Y+25）弹出。这使得视觉反馈非常自然。如果获取光标坐标失败，则会自动降级回原来的底部居中显示。
