### PR TITLE
ci: preserve existing Release asset counters

### DIFF
--- a/.github/workflows/release-promotion.yml
+++ b/.github/workflows/release-promotion.yml
@@ -151,11 +151,12 @@ jobs:
           这个列表统一展示 GitHub Release 下载文件，不代表已新增或验证应用内自动更新。请在更新时下载与自己系统匹配的文件。
           EOF
           if gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            : > promotion-evidence/missing-release-assets.txt
             while IFS= read -r asset; do
               local_digest="sha256:$(sha256sum "release-assets/$asset" | cut -d' ' -f1)"
               existing_digest="$(gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --json assets --jq ".assets[] | select(.name == \"$asset\") | .digest")"
               if [ -z "$existing_digest" ]; then
-                gh release upload "$RELEASE_TAG" "release-assets/$asset" --repo "$GITHUB_REPOSITORY"
+                echo "$asset" >> promotion-evidence/missing-release-assets.txt
               elif [ "$existing_digest" = "$local_digest" ]; then
                 echo "Preserving existing same-byte asset and download counter: $asset"
               else
@@ -163,6 +164,10 @@ jobs:
                 exit 1
               fi
             done < <(find release-assets -maxdepth 1 -type f -printf '%f\n' | sort)
+            while IFS= read -r asset; do
+              [ -n "$asset" ] || continue
+              gh release upload "$RELEASE_TAG" "release-assets/$asset" --repo "$GITHUB_REPOSITORY"
+            done < promotion-evidence/missing-release-assets.txt
             gh release edit "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --title "Whisper Input $RELEASE_TAG" --notes-file release-notes.zh-CN.md
           else
             gh release create "$RELEASE_TAG" release-assets/* --repo "$GITHUB_REPOSITORY" --title "Whisper Input $RELEASE_TAG" --notes-file release-notes.zh-CN.md

--- a/.github/workflows/release-promotion.yml
+++ b/.github/workflows/release-promotion.yml
@@ -151,11 +151,34 @@ jobs:
           这个列表统一展示 GitHub Release 下载文件，不代表已新增或验证应用内自动更新。请在更新时下载与自己系统匹配的文件。
           EOF
           if gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
-            gh release upload "$RELEASE_TAG" release-assets/* --clobber --repo "$GITHUB_REPOSITORY"
+            while IFS= read -r asset; do
+              local_digest="sha256:$(sha256sum "release-assets/$asset" | cut -d' ' -f1)"
+              existing_digest="$(gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --json assets --jq ".assets[] | select(.name == \"$asset\") | .digest")"
+              if [ -z "$existing_digest" ]; then
+                gh release upload "$RELEASE_TAG" "release-assets/$asset" --repo "$GITHUB_REPOSITORY"
+              elif [ "$existing_digest" = "$local_digest" ]; then
+                echo "Preserving existing same-byte asset and download counter: $asset"
+              else
+                echo "Existing Release asset has different bytes: $asset" >&2
+                exit 1
+              fi
+            done < <(find release-assets -maxdepth 1 -type f -printf '%f\n' | sort)
             gh release edit "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --title "Whisper Input $RELEASE_TAG" --notes-file release-notes.zh-CN.md
           else
             gh release create "$RELEASE_TAG" release-assets/* --repo "$GITHUB_REPOSITORY" --title "Whisper Input $RELEASE_TAG" --notes-file release-notes.zh-CN.md
           fi
+
+          release_json="$(gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --json assets,isDraft,isPrerelease)"
+          test "$(jq -r '.isDraft' <<<"$release_json")" = "false"
+          test "$(jq -r '.isPrerelease' <<<"$release_json")" = "false"
+          actual="$(jq -r '.assets[].name' <<<"$release_json" | sort)"
+          expected="$(find release-assets -maxdepth 1 -type f -printf '%f\n' | sort)"
+          test "$actual" = "$expected"
+          while IFS= read -r asset; do
+            expected_digest="sha256:$(sha256sum "release-assets/$asset" | cut -d' ' -f1)"
+            actual_digest="$(jq -r --arg asset "$asset" '.assets[] | select(.name == $asset) | .digest' <<<"$release_json")"
+            test "$actual_digest" = "$expected_digest"
+          done < <(find release-assets -maxdepth 1 -type f -printf '%f\n' | sort)
 
       - name: Upload promotion evidence
         if: always()


### PR DESCRIPTION
## 目的

本轮补齐 v1.3.34 Windows 资产时，promotion workflow 对已存在且字节相同的 macOS 资产使用 `--clobber`，导致 GitHub 重新创建资产并重置累计下载计数。

## 修改

- 已存在且 digest 相同：保留原资产和下载计数
- 资产缺失：只上传缺失资产
- 同名但 digest 不同：失败关闭，不覆盖
- 发布后读回完整资产集合、draft/prerelease 状态和每个 digest

## 验证

- `actionlint 1.7.12 .github/workflows/release-promotion.yml`
- `git diff --check`

此 PR 不再次运行发布，也不修改现有 Release。