### PR TITLE
ci: freeze v1.5.0 release contract

### DIFF
--- a/.github/workflows/release-promotion.yml
+++ b/.github/workflows/release-promotion.yml
@@ -6,7 +6,7 @@ on:
       contract_path:
         description: 冻结的发布契约路径
         required: true
-        default: release-contracts/v1.3.34.json
+        default: release-contracts/v1.5.0.json
         type: string
       windows_run_id:
         description: 成功的 Qualify Windows installers 工作流运行 ID

--- a/.github/workflows/windows-release-qualification.yml
+++ b/.github/workflows/windows-release-qualification.yml
@@ -6,7 +6,7 @@ on:
       contract_path:
         description: 冻结的发布契约路径
         required: true
-        default: release-contracts/v1.3.34.json
+        default: release-contracts/v1.5.0.json
         type: string
 
 # Windows 构建与安装验收不得创建或修改 GitHub Release。

--- a/docs/release-process.zh-CN.md
+++ b/docs/release-process.zh-CN.md
@@ -2,13 +2,13 @@
 
 一个 GitHub Release 可以同时挂载 macOS 与 Windows 的多个资产。为了避免先看到只有 macOS 文件、Windows 文件散落在另一个发布页，仓库把“构建与验收”和“上传到 Release”分开：只有两个平台的文件都校验合格后，提升工作流才创建或更新同一个 Release。
 
-## 对 v1.3.34 的冻结契约
+## 对 v1.5.0 的冻结契约
 
-- 标签：`v1.3.34`
-- 源码提交：`585116d2bf17f0d508c6d3dba536d5a35ded458c`
-- 详细资产、校验和验收基线：[`release-contracts/v1.3.34.json`](../release-contracts/v1.3.34.json)
+- 标签：`v1.5.0`
+- 源码提交：`e01a6de6b3c782b3682a641bb997ca1092142370`
+- 详细资产、校验和验收基线：[`release-contracts/v1.5.0.json`](../release-contracts/v1.5.0.json)
 
-Windows 构建会生成并实际验收 x64 EXE、MSI 和便携 ZIP：安装、启动、从 `v1.3.31` MSI 升级，以及卸载。它不会创建或改写 GitHub Release。
+Windows 构建会生成并实际验收 x64 EXE、MSI 和便携 ZIP：安装、启动、从 `v1.3.34` MSI 升级，以及卸载。它不会创建或改写 GitHub Release。
 
 ## 发布顺序
 

--- a/release-contracts/v1.5.0.json
+++ b/release-contracts/v1.5.0.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": 1,
+  "release": {
+    "tag": "v1.5.0",
+    "sourceCommit": "e01a6de6b3c782b3682a641bb997ca1092142370",
+    "title": "Whisper Input v1.5.0",
+    "productName": "Whisper Input",
+    "macos": {
+      "target": "aarch64-apple-darwin",
+      "assets": [
+        "Whisper_Input_1.5.0_arm64.dmg",
+        "Whisper_Input_1.5.0_arm64.dmg.sha256"
+      ],
+      "minimumSystemVersion": "12.0",
+      "signingStatus": "unsigned-and-not-notarized"
+    },
+    "windows": {
+      "target": "x86_64-pc-windows-msvc",
+      "assets": [
+        "Whisper_Input_1.5.0_x64_setup.exe",
+        "Whisper_Input_1.5.0_x64_setup.exe.sha256",
+        "Whisper_Input_1.5.0_x64_en-US.msi",
+        "Whisper_Input_1.5.0_x64_en-US.msi.sha256",
+        "Whisper_Input_1.5.0_x64_portable.zip",
+        "Whisper_Input_1.5.0_x64_portable.zip.sha256"
+      ],
+      "upgradeBaseline": {
+        "tag": "v1.3.34",
+        "msiAsset": "Whisper_Input_1.3.34_x64_en-US.msi"
+      },
+      "signingStatus": "no-authenticode-signing-step-configured",
+      "installationScope": "perMachine"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- bind the v1.5.0 release to frozen source `e01a6de6b3c782b3682a641bb997ca1092142370`
- declare the exact macOS arm64 and Windows x64 release asset sets
- use v1.3.34 MSI as the Windows upgrade baseline
- update workflow defaults and the release process reference

## Validation

- `v1.5.0` resolves to the frozen source SHA
- package, Tauri, and Cargo versions are all 1.5.0 at that SHA
- the v1.3.34 baseline MSI exists in the public Release
- Standards review: no findings
- Spec review: no findings