### PR TITLE
ci: freeze v1.5.3 release contract

### DIFF
--- a/.github/workflows/release-promotion.yml
+++ b/.github/workflows/release-promotion.yml
@@ -6,7 +6,7 @@ on:
       contract_path:
         description: 冻结的发布契约路径
         required: true
-        default: release-contracts/v1.5.2.json
+        default: release-contracts/v1.5.3.json
         type: string
       windows_run_id:
         description: 成功的 Qualify Windows installers 工作流运行 ID

--- a/.github/workflows/windows-release-qualification.yml
+++ b/.github/workflows/windows-release-qualification.yml
@@ -6,7 +6,7 @@ on:
       contract_path:
         description: 冻结的发布契约路径
         required: true
-        default: release-contracts/v1.5.2.json
+        default: release-contracts/v1.5.3.json
         type: string
 
 # Windows 构建与安装验收不得创建或修改 GitHub Release。

--- a/docs/release-process.zh-CN.md
+++ b/docs/release-process.zh-CN.md
@@ -2,11 +2,11 @@
 
 一个 GitHub Release 可以同时挂载 macOS 与 Windows 的多个资产。为了避免先看到只有 macOS 文件、Windows 文件散落在另一个发布页，仓库把“构建与验收”和“上传到 Release”分开：只有两个平台的文件都校验合格后，提升工作流才创建或更新同一个 Release。
 
-## 对 v1.5.2 的冻结契约
+## 对 v1.5.3 的冻结契约
 
-- 标签：`v1.5.2`
-- 源码提交：`ee635ba3fb6df3b383c92cee5d4c2d8c4561b3fa`
-- 详细资产、校验和验收基线：[`release-contracts/v1.5.2.json`](../release-contracts/v1.5.2.json)
+- 标签：`v1.5.3`
+- 源码提交：`05023b7269fb4991f8a9ebe4d8524b328382f09e`
+- 详细资产、校验和验收基线：[`release-contracts/v1.5.3.json`](../release-contracts/v1.5.3.json)
 
 Windows 构建会生成并实际验收 x64 EXE、MSI 和便携 ZIP：安装、启动、从 `v1.5.0` MSI 升级，以及卸载。它不会创建或改写 GitHub Release。
 

--- a/release-contracts/v1.5.3.json
+++ b/release-contracts/v1.5.3.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": 1,
+  "release": {
+    "tag": "v1.5.3",
+    "sourceCommit": "05023b7269fb4991f8a9ebe4d8524b328382f09e",
+    "title": "Whisper Input v1.5.3",
+    "productName": "Whisper Input",
+    "macos": {
+      "target": "aarch64-apple-darwin",
+      "assets": [
+        "Whisper_Input_1.5.3_arm64.dmg",
+        "Whisper_Input_1.5.3_arm64.dmg.sha256"
+      ],
+      "minimumSystemVersion": "12.0",
+      "signingStatus": "unsigned-and-not-notarized"
+    },
+    "windows": {
+      "target": "x86_64-pc-windows-msvc",
+      "assets": [
+        "Whisper_Input_1.5.3_x64_setup.exe",
+        "Whisper_Input_1.5.3_x64_setup.exe.sha256",
+        "Whisper_Input_1.5.3_x64_en-US.msi",
+        "Whisper_Input_1.5.3_x64_en-US.msi.sha256",
+        "Whisper_Input_1.5.3_x64_portable.zip",
+        "Whisper_Input_1.5.3_x64_portable.zip.sha256"
+      ],
+      "upgradeBaseline": {
+        "tag": "v1.5.2",
+        "msiAsset": "Whisper_Input_1.5.2_x64_en-US.msi"
+      },
+      "signingStatus": "no-authenticode-signing-step-configured",
+      "installationScope": "perMachine"
+    }
+  }
+}


### PR DESCRIPTION
Binds v1.5.3 to the merged source SHA and exact macOS/Windows asset set. Windows qualification upgrades from the published v1.5.2 MSI.